### PR TITLE
ads

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -40,6 +40,12 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         
+    - name: Set up Keystore
+      run: |
+        echo "${{ secrets.KEYSTORE_FILE }}" > project-led-release-key.jks
+        base64 -d project-led-release-key.jks > android/app/project-led-release-key.jks
+        rm project-led-release-key.jks
+
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
@@ -56,6 +62,10 @@ jobs:
         else
           flutter build apk --release
         fi
+      env:
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,14 +28,23 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-        minSdkVersion = 23
+        minSdkVersion 23
+    }
+
+    signingConfigs {
+        release {
+            storeFile file(System.getenv("KEYSTORE_PATH") ?: "project-led-release-key.jks")
+            storePassword System.getenv("KEYSTORE_PASSWORD")
+            keyAlias System.getenv("KEY_ALIAS")
+            keyPassword System.getenv("KEY_PASSWORD")
+        }
     }
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            signingConfig = signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
Add signing configuration for release builds in build.gradle and update build_android.yml to set up keystore for Android builds.